### PR TITLE
Fix format of clojure-cli options because TRAMP

### DIFF
--- a/cider.el
+++ b/cider.el
@@ -364,6 +364,10 @@ Throws an error if PROJECT-TYPE is unknown."
 
 (defun cider-jack-in-params (project-type)
   "Determine the commands params for `cider-jack-in' for the PROJECT-TYPE."
+  ;; The format of these command-line strings must consider different shells,
+  ;; different values of IFS, and the possibility that they'll be run remotely
+  ;; (e.g. with TRAMP). Using `", "` causes problems with TRAMP, for example.
+  ;; Please be careful when changing them.
   (pcase project-type
     ('lein        cider-lein-parameters)
     ('boot        cider-boot-parameters)
@@ -373,7 +377,7 @@ Throws an error if PROJECT-TYPE is unknown."
                            (mapconcat
                             (apply-partially #'format "\"%s\"")
                             (cider-jack-in-normalized-nrepl-middlewares)
-                            ", ")
+                            ",")
                            "]")))
     ('shadow-cljs cider-shadow-cljs-parameters)
     ('gradle      cider-gradle-parameters)


### PR DESCRIPTION
This is /a/ solution for https://github.com/clojure-emacs/clj-refactor.el/pull/445#issuecomment-628206640. I do not know what the cause of this problem is. Perhaps `IFS` is different between cider-jack-in versus directly on the command-line? Perhaps it's because TRAMP uses `/bin/sh` to run remote commands, not `/bin/bash`? I don't know. Given that `,` is whitespace in clojure, this seems like a harmless patch.

These changes are consistent with the contribution guidelines. The results of the tests and linter are unchanged by this patch. I do not believe this requires a mention in the CHANGELOG nor user manual.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (`eldev test`)
- [ ] All code passes the linter (`eldev lint`) which is based on [`elisp-lint`](https://github.com/gonewest818/elisp-lint) and includes
  - [byte-compilation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html), [`checkdoc`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html), [check-declare](https://www.gnu.org/software/emacs/manual/html_node/elisp/Declaring-Functions.html), packaging metadata, indentation, and trailing whitespace checks.
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!

*If you're just starting out to hack on CIDER you might find this [section of its
manual][1] extremely useful.*

[1]: https://docs.cider.mx/cider/contributing/hacking.html
